### PR TITLE
add RTL support for sidebar and improve code block display

### DIFF
--- a/style.css
+++ b/style.css
@@ -49,4 +49,21 @@
         direction: ltr;
     }
     
+    /* RTL support for five-level sidebar */
+    .notion-page-block > a > div {
+        padding-right: 8px!important;
+        padding-left: 8px!important;
+    }
+    .notion-outliner-team .notion-page-block > a > div {
+        padding-right: calc(8px + 8px)!important;
+    }
+    .notion-outliner-team .notion-page-block > .notion-outliner-team .notion-page-block > a > div {
+        padding-right: calc(8px + 8px + 8px)!important;
+    }
+    .notion-outliner-team .notion-page-block > .notion-outliner-team .notion-page-block > .notion-outliner-team .notion-page-block > a > div {
+        padding-right: calc(8px + 8px + 8px + 8px)!important;
+    }
+    .notion-outliner-team .notion-page-block > .notion-outliner-team .notion-page-block > .notion-outliner-team .notion-page-block > .notion-outliner-team .notion-page-block > a > div {
+        padding-right: calc(8px + 8px + 8px + 8px + 8px)!important;
+    }
 }

--- a/style.css
+++ b/style.css
@@ -2,29 +2,29 @@
     .notion-frame, .notion-sidebar, .notion-overlay-container {
         direction: rtl;
     }
-
+    
     .notion-frame .notion-scroller .notion-page-controls svg,
     .notion-overlay-container .notion-scroller .notion-page-controls svg {
         margin-right: 0 !important;
         margin-left: 6px
     }
-
+    
     .notion-topbar svg.check,
     .notion-overlay-container svg.check {
         margin-right: 0 !important;
         margin-left: 6px;
     }
-
+    
     .notion-frame .notion-page-content .notion-quote-block .notranslate {
         border-left: 0 !important;
         border-right: 3px solid;
     }
-
+    
     .notion-frame .notion-page-content .notion-to_do-block .notranslate,
     .notion-frame .notion-page-content .notion-bulleted_list-block .notranslate {
         text-align: right !important;
     }
-
+    
     #notion-app .notion-sidebar-container {
         float: right;
         right: 0;
@@ -32,17 +32,21 @@
         max-height: 100%;
         height: 100vh;
     }
-
+    
     #notion-app .notion-frame {
         float: left;
         left: 0;
         position: fixed;
     }
-
+    
     .notion-help-button {
         right: 100%;
         left: 33px;
     }
-
-
+    
+    /* LTR support for code blocks */
+    .notion-code-block {
+        direction: ltr;
+    }
+    
 }


### PR DESCRIPTION
add five-level RTL support for sidebar:

![image](https://github.com/user-attachments/assets/be9b1a47-5514-41a8-bad8-44939ea7edeb)

 and improve code block display in RTL mode:
 
![image](https://github.com/user-attachments/assets/1d07efdd-ff3b-4682-a2c3-a9ed45ad06b2)

