### PR TITLE
Fix: blockquote styling issues and apply code linting

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,30 +1,36 @@
-@-moz-document domain("notion.so"), domain("notion.site") {
-    .notion-frame, .notion-sidebar, .notion-overlay-container {
+@-moz-document domain("notion.so"),
+domain("notion.site") {
+    .notion-frame,
+    .notion-sidebar,
+    .notion-overlay-container {
         direction: rtl;
     }
-    
+
     .notion-frame .notion-scroller .notion-page-controls svg,
     .notion-overlay-container .notion-scroller .notion-page-controls svg {
         margin-right: 0 !important;
-        margin-left: 6px
+        margin-left: 6px;
     }
-    
+
     .notion-topbar svg.check,
     .notion-overlay-container svg.check {
         margin-right: 0 !important;
         margin-left: 6px;
     }
-    
+
     .notion-frame .notion-page-content .notion-quote-block .notranslate {
         border-left: 0 !important;
         border-right: 3px solid;
     }
-    
+
     .notion-frame .notion-page-content .notion-to_do-block .notranslate,
-    .notion-frame .notion-page-content .notion-bulleted_list-block .notranslate {
+    .notion-frame
+        .notion-page-content
+        .notion-bulleted_list-block
+        .notranslate {
         text-align: right !important;
     }
-    
+
     #notion-app .notion-sidebar-container {
         float: right;
         right: 0;
@@ -32,38 +38,67 @@
         max-height: 100%;
         height: 100vh;
     }
-    
+
     #notion-app .notion-frame {
         float: left;
         left: 0;
         position: fixed;
     }
-    
+
     .notion-help-button {
         right: 100%;
         left: 33px;
     }
-    
+
     /* LTR support for code blocks */
     .notion-code-block {
         direction: ltr;
     }
-    
+
     /* RTL support for five-level sidebar */
     .notion-page-block > a > div {
-        padding-right: 8px!important;
-        padding-left: 8px!important;
+        padding-right: 8px !important;
+        padding-left: 8px !important;
     }
     .notion-outliner-team .notion-page-block > a > div {
-        padding-right: calc(8px + 8px)!important;
+        padding-right: calc(8px + 8px) !important;
     }
-    .notion-outliner-team .notion-page-block > .notion-outliner-team .notion-page-block > a > div {
-        padding-right: calc(8px + 8px + 8px)!important;
+    .notion-outliner-team
+        .notion-page-block
+        > .notion-outliner-team
+        .notion-page-block
+        > a
+        > div {
+        padding-right: calc(8px + 8px + 8px) !important;
     }
-    .notion-outliner-team .notion-page-block > .notion-outliner-team .notion-page-block > .notion-outliner-team .notion-page-block > a > div {
-        padding-right: calc(8px + 8px + 8px + 8px)!important;
+    .notion-outliner-team
+        .notion-page-block
+        > .notion-outliner-team
+        .notion-page-block
+        > .notion-outliner-team
+        .notion-page-block
+        > a
+        > div {
+        padding-right: calc(8px + 8px + 8px + 8px) !important;
     }
-    .notion-outliner-team .notion-page-block > .notion-outliner-team .notion-page-block > .notion-outliner-team .notion-page-block > .notion-outliner-team .notion-page-block > a > div {
-        padding-right: calc(8px + 8px + 8px + 8px + 8px)!important;
+    .notion-outliner-team
+        .notion-page-block
+        > .notion-outliner-team
+        .notion-page-block
+        > .notion-outliner-team
+        .notion-page-block
+        > .notion-outliner-team
+        .notion-page-block
+        > a
+        > div {
+        padding-right: calc(8px + 8px + 8px + 8px + 8px) !important;
+    }
+
+    blockquote > div:nth-child(1) {
+        border-left: none !important;
+    }
+
+    blockquote > div:nth-child(1) > div:nth-child(1) {
+        padding-right: 14px !important;
     }
 }


### PR DESCRIPTION
Fix blockquote styling issues and apply code linting

- Removed extra left border on blockquotes using `border-left: none !important;`
- Adjusted padding on blockquote content with `padding-right: 14px !important;`
- Applied CSS linting for improved readability using [Code Beautify](https://codebeautify.org/css-beautify-minify) with a 4-space indent.

![image](https://github.com/user-attachments/assets/c1397cce-14e4-4fea-a12c-48f272deb25b)

fixes #9 